### PR TITLE
Added context kind to segment audience payload

### DIFF
--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,11 +6,12 @@ Object {
     Object {
       "cohortId": "test_audience",
       "cohortName": "Test audience",
-      "userId": "uKRBKG",
+      "userId": "user-id",
       "value": true,
     },
   ],
-  "environmentId": "uKRBKG",
+  "contextKind": "customContextKind",
+  "environmentId": "environment-id",
 }
 `;
 
@@ -22,6 +23,9 @@ Headers {
     ],
     "content-type": Array [
       "application/json",
+    ],
+    "ld-api-version": Array [
+      "20220603",
     ],
     "user-agent": Array [
       "SegmentSyncAudiences/1.0.0",

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/snapshot.test.ts
@@ -16,6 +16,11 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       eventData['segment_computation_action'] = 'audience'
       eventData['traits_or_props'] = { [eventData['custom_audience_name']]: true }
 
+      setStaticDataForSnapshot(eventData, 'context_kind', 'customContextKind')
+      setStaticDataForSnapshot(eventData, 'context_key', 'user-id')
+
+      setStaticDataForSnapshot(settingsData, 'clientId', 'environment-id')
+
       nock(/.*/).persist().get(/.*/).reply(200)
       nock(/.*/).persist().post(/.*/).reply(200)
       nock(/.*/).persist().put(/.*/).reply(200)
@@ -41,3 +46,14 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
     })
   }
 })
+
+/**
+ * Sets data used in snapshot tests to a static value to prevent snapshots from failing. Will only
+ * set override the value if its already set.
+ */
+const setStaticDataForSnapshot = (data: any, fieldName: string, staticValue: string) => {
+  if (data[fieldName]) {
+    data[fieldName] = staticValue
+  }
+  return data
+}

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,11 +6,12 @@ Object {
     Object {
       "cohortId": "test_audience",
       "cohortName": "Test audience",
-      "userId": "Zzm(mpiX(u6tjxt",
+      "userId": "user-id",
       "value": true,
     },
   ],
-  "environmentId": "Zzm(mpiX(u6tjxt",
+  "contextKind": "customContextKind",
+  "environmentId": "environment-id",
 }
 `;
 
@@ -18,10 +19,13 @@ exports[`Testing snapshot for LaunchDarklyAudiences's syncAudience destination a
 Headers {
   Symbol(map): Object {
     "authorization": Array [
-      "Zzm(mpiX(u6tjxt",
+      "&bUSudpNPsUWT",
     ],
     "content-type": Array [
       "application/json",
+    ],
+    "ld-api-version": Array [
+      "20220603",
     ],
     "user-agent": Array [
       "SegmentSyncAudiences/1.0.0",
@@ -36,11 +40,12 @@ Object {
     Object {
       "cohortId": "test_audience",
       "cohortName": "Test audience",
-      "userId": "Zzm(mpiX(u6tjxt",
+      "userId": "user-id",
       "value": false,
     },
   ],
-  "environmentId": "Zzm(mpiX(u6tjxt",
+  "contextKind": "customContextKind",
+  "environmentId": "environment-id",
 }
 `;
 
@@ -48,10 +53,13 @@ exports[`Testing snapshot for LaunchDarklyAudiences's syncAudience destination a
 Headers {
   Symbol(map): Object {
     "authorization": Array [
-      "Zzm(mpiX(u6tjxt",
+      "&bUSudpNPsUWT",
     ],
     "content-type": Array [
       "application/json",
+    ],
+    "ld-api-version": Array [
+      "20220603",
     ],
     "user-agent": Array [
       "SegmentSyncAudiences/1.0.0",

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/snapshot.test.ts
@@ -13,12 +13,13 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
     eventData['custom_audience_name'] = 'test_audience'
-    eventData['context_kind'] = 'customContextKind'
-    eventData['context_key'] = 'user-id'
     eventData['segment_computation_action'] = 'audience'
     eventData['traits_or_props'] = { [eventData['custom_audience_name']]: true }
 
-    settingsData['clientId'] = 'environment-id'
+    setStaticDataForSnapshot(eventData, 'context_kind', 'customContextKind')
+    setStaticDataForSnapshot(eventData, 'context_key', 'user-id')
+
+    setStaticDataForSnapshot(settingsData, 'clientId', 'environment-id')
 
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
@@ -48,12 +49,13 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
     eventData['custom_audience_name'] = 'test_audience'
-    eventData['context_kind'] = 'customContextKind'
-    eventData['context_key'] = 'user-id'
     eventData['segment_computation_action'] = 'audience'
     eventData['traits_or_props'] = { [eventData['custom_audience_name']]: false }
 
-    settingsData['clientId'] = 'environment-id'
+    setStaticDataForSnapshot(eventData, 'context_kind', 'customContextKind')
+    setStaticDataForSnapshot(eventData, 'context_key', 'user-id')
+
+    setStaticDataForSnapshot(settingsData, 'clientId', 'environment-id')
 
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
@@ -79,3 +81,14 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     expect(request.headers).toMatchSnapshot()
   })
 })
+
+/**
+ * Sets data used in snapshot tests to a static value to prevent snapshots from failing. Will only
+ * set override the value if its already set.
+ */
+const setStaticDataForSnapshot = (data: any, fieldName: string, staticValue: string) => {
+  if (data[fieldName]) {
+    data[fieldName] = staticValue
+  }
+  return data
+}

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/snapshot.test.ts
@@ -13,8 +13,12 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
     eventData['custom_audience_name'] = 'test_audience'
+    eventData['context_kind'] = 'customContextKind'
+    eventData['context_key'] = 'user-id'
     eventData['segment_computation_action'] = 'audience'
     eventData['traits_or_props'] = { [eventData['custom_audience_name']]: true }
+
+    settingsData['clientId'] = 'environment-id'
 
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
@@ -44,8 +48,12 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const action = destination.actions[actionSlug]
     const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
     eventData['custom_audience_name'] = 'test_audience'
+    eventData['context_kind'] = 'customContextKind'
+    eventData['context_key'] = 'user-id'
     eventData['segment_computation_action'] = 'audience'
     eventData['traits_or_props'] = { [eventData['custom_audience_name']]: false }
+
+    settingsData['clientId'] = 'environment-id'
 
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/custom-audience-operations.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/custom-audience-operations.ts
@@ -6,6 +6,7 @@ import { Settings } from '../generated-types'
 
 type AudienceBatch = {
   environmentId: string
+  contextKind: string
   batch: AudienceBatchItem[]
 }
 
@@ -57,12 +58,14 @@ const parseCustomAudienceBatches = (payload: Payload[], settings: Settings): Aud
     }
 
     const contextKey = p.context_key
+    const contextKind = p.context_kind
     const audienceId = p.custom_audience_name
     const traitsOrProps = p.traits_or_props
     const environmentId = settings.clientId
 
     let audienceBatch: AudienceBatch = {
       environmentId,
+      contextKind,
       batch: []
     }
 

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/generated-types.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   segment_computation_action: string
   /**
-   * The event's context kind. If not specified, the context kind will default to `user`. To learn more about context kinds and where you can find a list of context kinds LaunchDarkly has observed, read [Context kinds](https://docs.launchdarkly.com/home/contexts/context-kinds).
+   * The event's context kind. To learn more about context kinds and where you can find a list of context kinds LaunchDarkly has observed, read [Context kinds](https://docs.launchdarkly.com/home/contexts/context-kinds).
    */
   context_kind: string
   /**

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/index.ts
@@ -29,11 +29,10 @@ const action: ActionDefinition<Settings, Payload> = {
     context_kind: {
       label: 'Context kind',
       description:
-        "The event's context kind. If not specified, the context kind will default to `user`. To learn more about context kinds and where you can find a list of context kinds LaunchDarkly has observed, read [Context kinds](https://docs.launchdarkly.com/home/contexts/context-kinds).",
-      type: 'hidden',
+        "The event's context kind. To learn more about context kinds and where you can find a list of context kinds LaunchDarkly has observed, read [Context kinds](https://docs.launchdarkly.com/home/contexts/context-kinds).",
+      type: 'string',
       required: true,
-      default: 'user',
-      choices: [{ label: 'User', value: 'user' }]
+      default: 'user'
     },
     context_key: {
       label: 'Context key',


### PR DESCRIPTION
Added support for users to specify context kinds other the default `user` kind.

![Screenshot 2023-07-20 at 2 51 37 PM](https://github.com/launchdarkly/action-destinations/assets/82856282/33d2120e-98f9-47b3-91fb-df1d0fdabea8)

![Screenshot 2023-07-20 at 2 51 44 PM](https://github.com/launchdarkly/action-destinations/assets/82856282/ab05979d-bfea-433c-a8c8-7c2ec3ab75f2)
