### PR TITLE
[sc 210479] set static apiKey for snapshots

### DIFF
--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -19,7 +19,7 @@ exports[`Testing snapshot for actions-launchdarkly-audiences destination: syncAu
 Headers {
   Symbol(map): Object {
     "authorization": Array [
-      "uKRBKG",
+      "api-key",
     ],
     "content-type": Array [
       "application/json",

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/__tests__/snapshot.test.ts
@@ -20,6 +20,7 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       setStaticDataForSnapshot(eventData, 'context_key', 'user-id')
 
       setStaticDataForSnapshot(settingsData, 'clientId', 'environment-id')
+      setStaticDataForSnapshot(settingsData, 'apiKey', 'api-key')
 
       nock(/.*/).persist().get(/.*/).reply(200)
       nock(/.*/).persist().post(/.*/).reply(200)

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -19,7 +19,7 @@ exports[`Testing snapshot for LaunchDarklyAudiences's syncAudience destination a
 Headers {
   Symbol(map): Object {
     "authorization": Array [
-      "&bUSudpNPsUWT",
+      "api-key",
     ],
     "content-type": Array [
       "application/json",
@@ -53,7 +53,7 @@ exports[`Testing snapshot for LaunchDarklyAudiences's syncAudience destination a
 Headers {
   Symbol(map): Object {
     "authorization": Array [
-      "&bUSudpNPsUWT",
+      "api-key",
     ],
     "content-type": Array [
       "application/json",

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/snapshot.test.ts
@@ -20,6 +20,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     setStaticDataForSnapshot(eventData, 'context_key', 'user-id')
 
     setStaticDataForSnapshot(settingsData, 'clientId', 'environment-id')
+    setStaticDataForSnapshot(settingsData, 'apiKey', 'api-key')
 
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
@@ -56,6 +57,7 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     setStaticDataForSnapshot(eventData, 'context_key', 'user-id')
 
     setStaticDataForSnapshot(settingsData, 'clientId', 'environment-id')
+    setStaticDataForSnapshot(settingsData, 'apiKey', 'api-key')
 
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)


### PR DESCRIPTION
sets a static apiKey for snapshot tests, like we do already for clientId